### PR TITLE
Implement UI redesign with splash screen and particles

### DIFF
--- a/public/file.js
+++ b/public/file.js
@@ -8,17 +8,56 @@ function initProgressBar() {
     });
 }
 
+function applySavedTheme() {
+    const saved = localStorage.getItem('theme');
+    if (saved === 'light') {
+        document.body.classList.add('light');
+    }
+    const btn = document.getElementById('theme-toggle');
+    if (btn) btn.innerText = document.body.classList.contains('light') ? 'وضع ليلي' : 'وضع نهاري';
+}
+
 function toggleTheme() {
     const body = document.body;
     body.classList.toggle('light');
     const btn = document.getElementById('theme-toggle');
     if (btn) btn.innerText = body.classList.contains('light') ? 'وضع ليلي' : 'وضع نهاري';
+    localStorage.setItem('theme', body.classList.contains('light') ? 'light' : 'dark');
 }
 
 function copyToClipboard(text) {
     navigator.clipboard.writeText(text);
     alert('✅ تم نسخ المسار');
 }
+
+function createParticles() {
+    const bg = document.getElementById('particles-bg');
+    if (!bg) return;
+    const count = 40;
+    for (let i = 0; i < count; i++) {
+        const p = document.createElement('div');
+        p.className = 'particle';
+        const size = Math.random() * 6 + 4;
+        p.style.width = size + 'px';
+        p.style.height = size + 'px';
+        p.style.left = Math.random() * 100 + '%';
+        p.style.animationDuration = (5 + Math.random() * 5) + 's';
+        p.style.animationDelay = (Math.random() * 5) + 's';
+        bg.appendChild(p);
+    }
+    document.addEventListener('mousemove', e => {
+        const rect = bg.getBoundingClientRect();
+        const x = (e.clientX - rect.width / 2) / rect.width * 10;
+        bg.querySelectorAll('.particle').forEach(el => {
+            el.style.transform = `translateX(${x}px)`;
+        });
+    });
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    applySavedTheme();
+    createParticles();
+});
 
 function filterTypes() {
     const query = document.getElementById('search').value.toLowerCase();

--- a/public/index.html
+++ b/public/index.html
@@ -6,12 +6,12 @@
     <title>TARBOO API Hub</title>
     <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet" />
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css" />
+    <link rel="stylesheet" href="style.css" />
     <script src="https://unpkg.com/gsap@3.12.2/dist/gsap.min.js"></script>
     <script src="https://unpkg.com/gsap@3.12.2/dist/ScrollTrigger.min.js"></script>
     <style>
-        @import url('https://fonts.googleapis.com/css2?family=Cairo:wght@400;700&display=swap');
         body {
-            font-family: 'Cairo', sans-serif;
+            font-family: 'Tajawal', 'Cairo', sans-serif;
             overflow-x: hidden;
             background-color: #000;
             color: white;
@@ -251,8 +251,11 @@
     <!-- Splash Screen -->
     <div id="splash" class="splash-screen">
         <img src="https://i.ibb.co/0jQ3ZzG/logo.png" alt="TARBOO Logo" class="logo animate-pulse">
-        <h1 class="text-4xl font-bold mb-4 glow-title">مرحبًا بك في TARBOO API 🚀</h1>
-        <button onclick="enterSite()" class="btn-primary"><span>دخول الموقع</span></button>
+        <h1 class="text-4xl font-bold mb-4 glow-title gradient-text">مرحبًا بك في TARBOO API 🚀</h1>
+        <div id="progress-bar" class="w-2/3 h-2 bg-gray-700 rounded overflow-hidden">
+            <div id="progress" class="h-full w-0 bg-gradient-to-r from-purple-700 via-pink-500 to-yellow-400"></div>
+        </div>
+        <button onclick="enterSite()" class="btn-primary mt-4"><span>دخول الموقع</span></button>
     </div>
 
     <!-- Background Video -->
@@ -260,17 +263,23 @@
         <source src="https://files.catbox.moe/5etht6.mp4" type="video/webm" />
     </video>
     <div class="overlay"></div>
+    <div id="particles-bg" class="particles-bg"></div>
 
     <!-- Header -->
-    <header class="text-center pt-20">
-        <h1 id="main-title" class="text-4xl md:text-5xl bg-white bg-opacity-10 px-6 py-2 rounded-xl backdrop-blur glow-title">TARBOO API</h1>
+    <header class="fixed top-0 w-full flex justify-between items-center px-6 py-3 bg-white bg-opacity-10 backdrop-blur z-20">
+        <h1 id="main-title" class="text-2xl font-extrabold gradient-text">TARBOO</h1>
+        <nav class="space-x-4 space-x-reverse hidden md:block">
+            <a href="#services" class="hover:underline">الخدمات</a>
+            <a href="#features" class="hover:underline">المميزات</a>
+            <a href="#contact" class="hover:underline">تواصل معنا</a>
+        </nav>
+        <button id="theme-toggle" onclick="toggleTheme()" class="btn-send text-sm" aria-label="تغيير الثيم">وضع نهاري</button>
     </header>
 
     <!-- Container for API types -->
-    <main class="flex flex-col items-center px-4 py-10">
+    <main class="flex flex-col items-center px-4 py-20">
         <div class="flex gap-2 mb-6 w-full max-w-md">
             <input id="search" type="text" oninput="filterTypes()" placeholder="ابحث..." class="flex-1 p-2 rounded text-black" />
-            <button id="theme-toggle" onclick="toggleTheme()" class="btn-send">وضع نهاري</button>
         </div>
         <p id="message" class="text-gray-300 mb-6">جارٍ تحميل البيانات...</p>
         <div id="type-container" class="grid grid-cols-1 md:grid-cols-2 gap-6 max-w-3xl w-full"></div>
@@ -308,6 +317,16 @@
                     animatePageIn();
                 },
             });
+        }
+
+        function simulateLoading() {
+            const bar = document.getElementById("progress");
+            let p = 0;
+            const int = setInterval(() => {
+                p += 1;
+                if (bar) bar.style.width = p + "%";
+                if (p >= 100) clearInterval(int);
+            }, 40);
         }
 
         function toggleChat() {
@@ -370,6 +389,7 @@
 
         loadTypes();
         initProgressBar();
+        simulateLoading();
     </script>
 </body>
 </html>

--- a/public/style.css
+++ b/public/style.css
@@ -1,3 +1,5 @@
+@import url('https://fonts.googleapis.com/css2?family=Tajawal:wght@300;400;700;800&family=Cairo:wght@400;700;800&display=swap');
+
 /* Reset and Global Styles */
 * {
   margin: 0;
@@ -6,7 +8,7 @@
 }
 
 body {
-  font-family: 'Roboto', Arial, sans-serif;
+  font-family: 'Tajawal', 'Cairo', sans-serif;
   background-color: #f4f7fc;
   color: #333;
   line-height: 1.6;
@@ -112,4 +114,42 @@ body {
   background: #1a1a1a;
   color: white;
   margin-top: 2rem;
+}
+
+/* Gradient text utility */
+.gradient-text {
+  background: linear-gradient(90deg, #6d28d9, #ec4899, #0ea5e9);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  color: transparent;
+}
+
+/* Particles background */
+.particles-bg {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  z-index: -2;
+}
+
+.particle {
+  position: absolute;
+  bottom: -10px;
+  background: rgba(255, 255, 255, 0.15);
+  border-radius: 50%;
+  pointer-events: none;
+  animation: floatUp linear infinite;
+}
+
+@keyframes floatUp {
+  from {
+    transform: translateY(0);
+  }
+  to {
+    transform: translateY(-110vh);
+  }
 }

--- a/public/type.html
+++ b/public/type.html
@@ -1,14 +1,15 @@
 <!DOCTYPE html>
-<html lang="ar">
+<html lang="ar" dir="rtl">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>TARBOO-API</title>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css">
+    <link rel="stylesheet" href="style.css">
     <style>
         /* خلفية الصفحة */
         body {
-            font-family: 'Arial', sans-serif;
+            font-family: 'Tajawal', 'Cairo', sans-serif;
             text-align: center;
             background: linear-gradient(135deg, #0a0027, #22004d, #66008d);
             color: white;
@@ -162,15 +163,20 @@
 <body>
 
     <div id="scroll-progress"></div>
+    <div id="particles-bg" class="particles-bg"></div>
+    <header class="fixed top-0 w-full flex justify-between items-center px-6 py-3 bg-white bg-opacity-10 backdrop-blur z-20">
+        <h1 id="page-title" class="text-2xl font-extrabold gradient-text">TARBOO-API</h1>
+        <button id="theme-toggle" onclick="toggleTheme()" class="btn-send text-sm" aria-label="تغيير الثيم">وضع نهاري</button>
+    </header>
 
-    <h1 id="page-title">TARBOO-API</h1>
-    <div class="flex gap-2 my-4 w-full max-w-md mx-auto">
-        <input id="search" type="text" oninput="filterAPIs()" placeholder="ابحث..." class="flex-1 p-2 rounded text-black" />
-        <button id="theme-toggle" onclick="toggleTheme()" class="btn-send">وضع نهاري</button>
-    </div>
-    <div class="container" id="api-container">
-        <!-- سيتم تحميل الـ APIs هنا -->
-    </div>
+    <main class="pt-20">
+        <div class="flex gap-2 my-4 w-full max-w-md mx-auto">
+            <input id="search" type="text" oninput="filterAPIs()" placeholder="ابحث..." class="flex-1 p-2 rounded text-black" />
+        </div>
+        <div class="container" id="api-container">
+            <!-- سيتم تحميل الـ APIs هنا -->
+        </div>
+    </main>
 
     <script src="file.js"></script>
     <script>


### PR DESCRIPTION
## Summary
- add Tajawal & Cairo fonts
- introduce gradient text and particle effects in CSS
- redesign index page header and splash screen
- keep theme choice in localStorage
- add particles and fixed header in type page

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6853273afaec8325812a7fdc1b9cc6f9