### PR TITLE
Improve user feedback with toast and ripple effects

### DIFF
--- a/public/file.js
+++ b/public/file.js
@@ -41,9 +41,23 @@ function setTheme(mode) {
     localStorage.setItem('theme', mode);
 }
 
+function showToast(msg) {
+    const container = document.getElementById('toast-container');
+    if (!container) return;
+    const el = document.createElement('div');
+    el.className = 'toast';
+    el.textContent = msg;
+    container.appendChild(el);
+    requestAnimationFrame(() => el.classList.add('show'));
+    setTimeout(() => {
+        el.classList.remove('show');
+        el.addEventListener('transitionend', () => el.remove());
+    }, 2000);
+}
+
 function copyToClipboard(text) {
     navigator.clipboard.writeText(text);
-    alert('✅ تم نسخ المسار');
+    showToast('✅ تم النسخ!');
 }
 
 const translations = {
@@ -132,6 +146,11 @@ document.addEventListener('DOMContentLoaded', () => {
             localStorage.setItem('lang', newLang);
         });
     }
+
+    document.body.addEventListener('click', e => {
+        const btn = e.target.closest('.btn-cta, .btn-theme, .copy-btn');
+        if (btn) addRippleEffect.call(btn, e);
+    });
 });
 
 function filterTypes() {
@@ -146,4 +165,17 @@ function filterAPIs() {
     document.querySelectorAll('.api-box').forEach(box => {
         box.style.display = box.innerText.toLowerCase().includes(query) ? 'block' : 'none';
     });
+}
+
+function addRippleEffect(e) {
+    const btn = e.currentTarget;
+    const circle = document.createElement('span');
+    const diameter = Math.max(btn.clientWidth, btn.clientHeight);
+    circle.style.width = circle.style.height = diameter + 'px';
+    circle.style.left = e.clientX - btn.getBoundingClientRect().left - diameter/2 + 'px';
+    circle.style.top = e.clientY - btn.getBoundingClientRect().top - diameter/2 + 'px';
+    circle.className = 'ripple';
+    const ripple = btn.getElementsByClassName('ripple')[0];
+    if (ripple) ripple.remove();
+    btn.appendChild(circle);
 }

--- a/public/index.html
+++ b/public/index.html
@@ -190,6 +190,7 @@
       background: linear-gradient(90deg, #6d28d9, #ec4899, #fbbf24);
       color: #fff; box-shadow: 0 4px 16px #6d28d9a0;
       transition: box-shadow 0.2s, transform 0.2s;
+      position: relative; overflow: hidden;
     }
 
     .theme-select button { padding: 6px 14px; }
@@ -259,6 +260,46 @@
     /* تأثيرات النص */
     .glow-text {
       text-shadow: 0 0 10px rgba(109, 40, 217, 0.7);
+    }
+
+    /* Ripple effect */
+    .ripple {
+      position: absolute;
+      border-radius: 50%;
+      transform: scale(0);
+      background: rgba(255,255,255,0.4);
+      animation: rippleAnim 0.6s linear;
+      pointer-events: none;
+    }
+    @keyframes rippleAnim {
+      to { transform: scale(4); opacity: 0; }
+    }
+
+    /* Toasts */
+    #toast-container {
+      position: fixed;
+      bottom: 1.5rem;
+      left: 50%;
+      transform: translateX(-50%);
+      z-index: 9999;
+      display: flex;
+      flex-direction: column;
+      gap: 0.5rem;
+      align-items: center;
+    }
+    .toast {
+      background: rgba(15,23,42,0.9);
+      color: #fff;
+      padding: 0.6rem 1.2rem;
+      border-radius: 999px;
+      opacity: 0;
+      transform: translateY(20px);
+      transition: opacity .4s, transform .4s;
+      pointer-events: none;
+    }
+    .toast.show {
+      opacity: 1;
+      transform: translateY(0);
     }
   </style>
 </head>
@@ -426,6 +467,8 @@
       </p>
     </div>
   </footer>
+
+  <div id="toast-container"></div>
 
   <script>
     // -------------------- جسيمات الخلفية ----------------------

--- a/public/type.html
+++ b/public/type.html
@@ -130,6 +130,8 @@
             border: none;
             border-radius: 6px;
             cursor: pointer;
+            position: relative;
+            overflow: hidden;
         }
 
         .copy-btn:hover {
@@ -158,6 +160,44 @@
             color: #000;
         }
 
+        .ripple {
+            position: absolute;
+            border-radius: 50%;
+            transform: scale(0);
+            background: rgba(255,255,255,0.4);
+            animation: rippleAnim 0.6s linear;
+            pointer-events: none;
+        }
+        @keyframes rippleAnim {
+            to { transform: scale(4); opacity: 0; }
+        }
+
+        #toast-container {
+            position: fixed;
+            bottom: 1.5rem;
+            left: 50%;
+            transform: translateX(-50%);
+            z-index: 9999;
+            display: flex;
+            flex-direction: column;
+            gap: 0.5rem;
+            align-items: center;
+        }
+        .toast {
+            background: rgba(15,23,42,0.9);
+            color: #fff;
+            padding: 0.6rem 1.2rem;
+            border-radius: 999px;
+            opacity: 0;
+            transform: translateY(20px);
+            transition: opacity .4s, transform .4s;
+            pointer-events: none;
+        }
+        .toast.show {
+            opacity: 1;
+            transform: translateY(0);
+        }
+
     </style>
 </head>
 <body>
@@ -180,6 +220,8 @@
             <!-- سيتم تحميل الـ APIs هنا -->
         </div>
     </main>
+
+    <div id="toast-container"></div>
 
     <script src="file.js"></script>
     <script>


### PR DESCRIPTION
## Summary
- show toast notifications instead of alert on copy
- add ripple animation on button clicks
- include shared toast container in pages
- style ripple and toast elements

## Testing
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_6855e2a96e40832583e512a5f89b0440